### PR TITLE
Follow symlinks on MacOS

### DIFF
--- a/edgedbpkg/pyentrypoint/rust/Cargo.toml
+++ b/edgedbpkg/pyentrypoint/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyentrypoint"
 version = "1.0.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]

--- a/edgedbpkg/pyentrypoint/rust/src/main.rs
+++ b/edgedbpkg/pyentrypoint/rust/src/main.rs
@@ -3,17 +3,26 @@ use std::os::unix::process::CommandExt;
 use std::process::Command;
 
 fn main() {
-    let exe = std::env::current_exe().unwrap();
+    let mut exe = std::env::current_exe().unwrap();
+    if exe.is_symlink() {
+        match exe.canonicalize() {
+            Ok(target) => exe = target,
+            Err(e) => panic!("failed to canonicalize executable path {exe:?}: {e:?}"),
+        }
+    }
     let exe_dir = match exe.parent() {
         Some(dir) => dir,
         None => panic!("current executable path is not a file?"),
     };
     let python = exe_dir.join("python3");
+    if !python.exists() {
+        panic!("python3 not found in {exe_dir:?}");
+    }
     let mut args: Vec<_> = std::env::args_os().skip(1).collect();
     let mut py_script = exe.clone();
     py_script.set_extension("py");
     let mut script_args = vec![OsString::from("-I"), OsString::from(py_script)];
     script_args.append(&mut args);
-    let err = Command::new(python).args(&script_args).exec();
-    panic!("{:?}", err);
+    let err = Command::new(&python).args(&script_args).exec();
+    panic!("failed to execute {python:?}: {err:?}");
 }


### PR DESCRIPTION
MacOS seems to launch symlinks with argv[0] pointing at the symlink rather than the final resolved file.