### PR TITLE
Fix unrenamed bits in system units shipped in native packages

### DIFF
--- a/edgedbpkg/edgedb/IDENTIFIER-SLOT.plist.in
+++ b/edgedbpkg/edgedb/IDENTIFIER-SLOT.plist.in
@@ -11,9 +11,9 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>@@{bindir}/edgedb-server</string>
-        <string>--data-dir=@@{localstatedir}/lib/edgedb/@@{slot}/data/</string>
-        <string>--runstate-dir=@@{runstatedir}/edgedb/</string>
+        <string>@@{bindir}/@@{name}</string>
+        <string>--data-dir=@@{localstatedir}/lib/@@{name_for_user_and_dir}/@@{slot}/data/</string>
+        <string>--runstate-dir=@@{runstatedir}/@@{name_for_user_and_dir}/</string>
         <string>--tls-cert-mode=generate_self_signed</string>
     </array>
 
@@ -21,7 +21,7 @@
     <true/>
 
     <key>UserName</key>
-    <string>edgedb</string>
+    <string>@@{name_for_user_and_dir}</string>
 
     <key>KeepAlive</key>
     <dict>

--- a/edgedbpkg/edgedb/IDENTIFIER-SLOT.service.in
+++ b/edgedbpkg/edgedb/IDENTIFIER-SLOT.service.in
@@ -7,13 +7,14 @@ After=network.target
 [Service]
 Type=notify
 
-User=edgedb
-Group=edgedb
+User=@@{name_for_user_and_dir}
+Group=@@{name_for_user_and_dir}
 
-Environment=EDGEDATA=@@{localstatedir}/lib/edgedb/@@{slot}/data/
-RuntimeDirectory=edgedb
+Environment=GELDATA=@@{localstatedir}/lib/@@{name_for_user_and_dir}/@@{slot}/data/
+RuntimeDirectory=@@{name_for_user_and_dir}
 
-ExecStart=@@{bindir}/edgedb-server --data-dir=${EDGEDATA} --runstate-dir=%t/edgedb --tls-cert-mode=generate_self_signed
+ExecStartPre=@@{pre_start_script}
+ExecStart=@@{bindir}/@@{name} --data-dir=${GELDATA} --runstate-dir=%t/@@{name_for_user_and_dir} --tls-cert-mode=generate_self_signed
 ExecReload=/bin/kill -HUP ${MAINPID}
 KillMode=mixed
 KillSignal=SIGINT


### PR DESCRIPTION
This is a bit of a SNAFU, because the service units are broken on fresh
systems, and on systems where EdgeDB 5.x and earlier was installed they
would work, but will initialize the data in the wrong spot
(`/var/lib/edgedb`) and owned by the wrong user (`edgedb`).  This fixes
the units and adds a check that errors out if the wrong data directory
is detected, so people who have successfully installed Gel 6.0/6.1 would
be informed to move and `chown` the data directory when upgrading to 6.2
and later.
