### PR TITLE
Only create bucket redirects for uncompressed versions

### DIFF
--- a/server/process_incoming.py
+++ b/server/process_incoming.py
@@ -739,7 +739,7 @@ def process_generic(
         put(bucket, metadata_path, archive_dir, cache=True)
 
         links = metadata.get("publish_link_to_latest")
-        if links:
+        if links and desc.get("encoding") == "identity":
             if isinstance(links, bool):
                 links = [basename]
             else:


### PR DESCRIPTION
S3 has a hard limit of 50 redirect rules and we overflow those with the
combination of channels, platforms, compression formats and the rebrand.
This buys us more breathing room by only publishing the redirect to an
uncompressed binary, which is what we use anyway.
