### PR TITLE
Update setuptools to 77 for GelNoPostgres

### DIFF
--- a/edgedbpkg/edgedb/__init__.py
+++ b/edgedbpkg/edgedb/__init__.py
@@ -106,7 +106,7 @@ class GelNoPostgres(packages.BundledPythonPackage):
     common_build_reqs: packages.RequirementsSpec = {
         "*": [
             "pyentrypoint (>=1.0.0)",
-            "pypkg-setuptools (<70.2.0)",
+            "pypkg-setuptools (~= 77.0)",
         ],
     }
 

--- a/edgedbpkg/edgedb/__init__.py
+++ b/edgedbpkg/edgedb/__init__.py
@@ -106,7 +106,6 @@ class GelNoPostgres(packages.BundledPythonPackage):
     common_build_reqs: packages.RequirementsSpec = {
         "*": [
             "pyentrypoint (>=1.0.0)",
-            "pypkg-setuptools (~= 77.0)",
         ],
     }
 

--- a/integration/linux/build/_bootstrap/python.sh
+++ b/integration/linux/build/_bootstrap/python.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-: ${PYTHON_VERSION:=3.12.7}
-: ${PYTHON_PIP_VERSION:=24.2}
+: ${PYTHON_VERSION:=3.12.9}
+: ${PYTHON_PIP_VERSION:=25.0.1}
 
 source "${BASH_SOURCE%/*}/_helpers.sh"
 

--- a/integration/linux/build/amazonlinux-2023/Dockerfile
+++ b/integration/linux/build/amazonlinux-2023/Dockerfile
@@ -148,7 +148,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\
@@ -164,14 +164,6 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -325,6 +317,14 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\

--- a/integration/linux/build/amazonlinux-2023/Dockerfile
+++ b/integration/linux/build/amazonlinux-2023/Dockerfile
@@ -164,6 +164,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -317,14 +325,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -525,8 +525,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/centos-7/Dockerfile
+++ b/integration/linux/build/centos-7/Dockerfile
@@ -150,7 +150,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/centos-7/Dockerfile
+++ b/integration/linux/build/centos-7/Dockerfile
@@ -166,6 +166,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -319,14 +327,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -527,8 +527,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/centos-8/Dockerfile
+++ b/integration/linux/build/centos-8/Dockerfile
@@ -146,7 +146,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/centos-8/Dockerfile
+++ b/integration/linux/build/centos-8/Dockerfile
@@ -162,6 +162,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -315,14 +323,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -523,8 +523,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/debian-bookworm/Dockerfile
+++ b/integration/linux/build/debian-bookworm/Dockerfile
@@ -116,7 +116,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/debian-bookworm/Dockerfile
+++ b/integration/linux/build/debian-bookworm/Dockerfile
@@ -132,6 +132,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -285,14 +293,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -493,8 +493,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/debian-bullseye/Dockerfile
+++ b/integration/linux/build/debian-bullseye/Dockerfile
@@ -116,7 +116,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/debian-bullseye/Dockerfile
+++ b/integration/linux/build/debian-bullseye/Dockerfile
@@ -132,6 +132,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -285,14 +293,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -493,8 +493,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/debian-buster/Dockerfile
+++ b/integration/linux/build/debian-buster/Dockerfile
@@ -116,7 +116,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/debian-buster/Dockerfile
+++ b/integration/linux/build/debian-buster/Dockerfile
@@ -132,6 +132,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -285,14 +293,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -493,8 +493,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/entrypoint.sh
+++ b/integration/linux/build/entrypoint.sh
@@ -82,7 +82,7 @@ if [ -z "${VIRTUAL_ENV}"]; then
     ${PYTHON} -m pip install -U pip setuptools wheel
 fi
 
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools
 
 if [ -n "${METAPKG_PATH}" ]; then
     p=$(${PYTHON} -c 'import metapkg;print(metapkg.__path__[0])')

--- a/integration/linux/build/fedora-40/Dockerfile
+++ b/integration/linux/build/fedora-40/Dockerfile
@@ -143,7 +143,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/fedora-40/Dockerfile
+++ b/integration/linux/build/fedora-40/Dockerfile
@@ -159,6 +159,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -312,14 +320,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -520,8 +520,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/linux-aarch64/Dockerfile
+++ b/integration/linux/build/linux-aarch64/Dockerfile
@@ -159,7 +159,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/linux-aarch64/Dockerfile
+++ b/integration/linux/build/linux-aarch64/Dockerfile
@@ -175,6 +175,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -328,14 +336,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -536,8 +536,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/linux-x86_64/Dockerfile
+++ b/integration/linux/build/linux-x86_64/Dockerfile
@@ -159,7 +159,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/linux-x86_64/Dockerfile
+++ b/integration/linux/build/linux-x86_64/Dockerfile
@@ -175,6 +175,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -328,14 +336,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -536,8 +536,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/linuxmusl-aarch64/Dockerfile
+++ b/integration/linux/build/linuxmusl-aarch64/Dockerfile
@@ -134,7 +134,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/linuxmusl-aarch64/Dockerfile
+++ b/integration/linux/build/linuxmusl-aarch64/Dockerfile
@@ -150,6 +150,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -303,14 +311,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -511,8 +511,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/linuxmusl-x86_64/Dockerfile
+++ b/integration/linux/build/linuxmusl-x86_64/Dockerfile
@@ -134,7 +134,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/linuxmusl-x86_64/Dockerfile
+++ b/integration/linux/build/linuxmusl-x86_64/Dockerfile
@@ -150,6 +150,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -303,14 +311,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -511,8 +511,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/rockylinux-9/Dockerfile
+++ b/integration/linux/build/rockylinux-9/Dockerfile
@@ -163,6 +163,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -316,14 +324,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -524,8 +524,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/rockylinux-9/Dockerfile
+++ b/integration/linux/build/rockylinux-9/Dockerfile
@@ -147,7 +147,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/ubuntu-bionic/Dockerfile
+++ b/integration/linux/build/ubuntu-bionic/Dockerfile
@@ -116,7 +116,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/ubuntu-bionic/Dockerfile
+++ b/integration/linux/build/ubuntu-bionic/Dockerfile
@@ -132,6 +132,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -285,14 +293,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -493,8 +493,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/ubuntu-focal/Dockerfile
+++ b/integration/linux/build/ubuntu-focal/Dockerfile
@@ -116,7 +116,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/ubuntu-focal/Dockerfile
+++ b/integration/linux/build/ubuntu-focal/Dockerfile
@@ -132,6 +132,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -285,14 +293,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -493,8 +493,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/ubuntu-hirsute/Dockerfile
+++ b/integration/linux/build/ubuntu-hirsute/Dockerfile
@@ -116,7 +116,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/ubuntu-hirsute/Dockerfile
+++ b/integration/linux/build/ubuntu-hirsute/Dockerfile
@@ -132,6 +132,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -285,14 +293,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -493,8 +493,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/ubuntu-jammy/Dockerfile
+++ b/integration/linux/build/ubuntu-jammy/Dockerfile
@@ -116,7 +116,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/ubuntu-jammy/Dockerfile
+++ b/integration/linux/build/ubuntu-jammy/Dockerfile
@@ -132,6 +132,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -285,14 +293,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -493,8 +493,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/ubuntu-noble/Dockerfile
+++ b/integration/linux/build/ubuntu-noble/Dockerfile
@@ -116,7 +116,7 @@ if [ -z "${VIRTUAL_ENV}"]; then\n\
     ${PYTHON} -m pip install -U pip setuptools wheel\n\
 fi\n\
 \n\
-${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg\n\
+${PYTHON} -m pip install -U git+https://github.com/edgedb/edgedb-pkg@update-setuptools\n\
 \n\
 if [ -n "${METAPKG_PATH}" ]; then\n\
     p=$(${PYTHON} -c '\''import metapkg;print(metapkg.__path__[0])'\'')\n\

--- a/integration/linux/build/ubuntu-noble/Dockerfile
+++ b/integration/linux/build/ubuntu-noble/Dockerfile
@@ -132,6 +132,14 @@ else\n\
     ${PYTHON} -m metapkg build -vvv --dest="${dest}" ${extraopts} "${PACKAGE}"\n\
     ls -al "${dest}"\n\
 fi\n\' >/entrypoint.sh; chmod +x /entrypoint.sh
+RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
+    for key in "${@}"; do\n\
+        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
+        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
+    done\n\
+}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -285,14 +293,6 @@ make -j $(nproc)\n\
 make install\n\
 cd /usr/src\n\
 rm -rf /usr/src/gzip\n\' >/_bootstrap/gzip.sh; chmod +x /_bootstrap/gzip.sh
-RUN mkdir -p '_bootstrap'; /bin/echo -e 'function fetch_keys() {\n\
-    for key in "${@}"; do\n\
-        gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" \\\n\
-        || gpg --batch --keyserver keys.openpgp.org --recv-keys "$key"\n\
-    done\n\
-}\n\' >/_bootstrap/_helpers.sh; chmod +x /_bootstrap/_helpers.sh
 RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
@@ -493,8 +493,8 @@ RUN mkdir -p '_bootstrap'; /bin/echo -e '#!/usr/bin/env bash\n\
 \n\
 set -ex\n\
 \n\
-: ${PYTHON_VERSION:=3.12.7}\n\
-: ${PYTHON_PIP_VERSION:=24.2}\n\
+: ${PYTHON_VERSION:=3.12.9}\n\
+: ${PYTHON_PIP_VERSION:=25.0.1}\n\
 \n\
 source "${BASH_SOURCE%/*}/_helpers.sh"\n\
 \n\

--- a/integration/linux/build/update.sh
+++ b/integration/linux/build/update.sh
@@ -127,7 +127,7 @@ $SED -ri \
 
 embed_script entrypoint.sh "$target"
 
-for bootstrap in _bootstrap/*.sh; do
+for bootstrap in $(ls _bootstrap/*.sh | sort); do
 	embed_script "$bootstrap" "$target"
 done
 


### PR DESCRIPTION
It was originally pinned by #101.

I'm keeping a pin on a major verson, because upgrading major
version automatically might cause breakage in the future.

I need this update, because calver has published a broken
version, followed by a fix that bumps required setuptools.
Which means we cannot use the fix unless we update setuptools.
