### PR TITLE
Add pg_waldump to postgres server package

### DIFF
--- a/edgedbpkg/postgresql/install.list
+++ b/edgedbpkg/postgresql/install.list
@@ -7,6 +7,7 @@
 {bindir}/pg_restore
 {bindir}/pg_rewind
 {bindir}/pg_verifybackup
+{bindir}/pg_waldump
 {bindir}/psql
 {bindir}/postgres
 {libdir}/postgresql/*.so


### PR DESCRIPTION
`pg_waldump` is required by `pg_verifybackup`