### PR TITLE
Fix missing $PYTHON command

### DIFF
--- a/integration/win/build.sh
+++ b/integration/win/build.sh
@@ -3,6 +3,8 @@
 set -Exeo pipefail
 shopt -s nullglob
 
+PYTHON=${PYTHON:-python3}
+
 # Circumvent a dubious practice of Windows intercepting
 # bare invocations of "bash" to mean "WSL", since make
 # runs its shells using bare names even if SHELL contains


### PR DESCRIPTION
The error was:

https://github.com/geldata/gel-cli/actions/runs/14844894394/job/41680123790#step:6:77

```
+ -m venv .venv
edgedb-pkg/integration/win/build.sh: line 72: -m: command not found
```