### PR TITLE
Fix venv path on windows

### DIFF
--- a/integration/win/build.sh
+++ b/integration/win/build.sh
@@ -72,7 +72,7 @@ fi
 
 if [ -z "${VIRTUAL_ENV}"]; then
     ${PYTHON} -m venv .venv
-    source .venv/bin/activate
+    source .venv/Scripts/activate
     ${PYTHON} -m pip install -U pip setuptools wheel
 fi
 


### PR DESCRIPTION
The virtualenv on Windows uses `Scripts` instead of `bin`

Refs #160, aa03e30e21d70f2364355a7ea2a09873df61c110