### PR TITLE
Fix debian buster build

### DIFF
--- a/integration/linux/build/Dockerfile-debian.template
+++ b/integration/linux/build/Dockerfile-debian.template
@@ -7,6 +7,10 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 %%ENV%%
 
+%%IF VARIANT=debian-buster%%
+# Buster is out of support, point it at archive.debian.org
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+%%ENDIF%%
 RUN apt-get update \
 	&& apt-get dist-upgrade -y \
 	&& apt-get install -y --no-install-recommends \

--- a/integration/linux/build/debian-buster/Dockerfile
+++ b/integration/linux/build/debian-buster/Dockerfile
@@ -25,6 +25,8 @@ ENV SCCACHE_GHA_ENABLED=$SCCACHE_GHA_ENABLED
 ENV ACTIONS_CACHE_SERVICE_V2=$ACTIONS_CACHE_SERVICE_V2
 
 
+# Buster is out of support, point it at archive.debian.org
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
 RUN apt-get update \
 	&& apt-get dist-upgrade -y \
 	&& apt-get install -y --no-install-recommends \


### PR DESCRIPTION
It is out of support, so point it at archive.debian.org instead.
We'll want to drop it, but probably not for 6.x.

Apparently we have support for casing on the variant in our template
files... I learned a lot more about sed today trying to understand
what update.sh was doing.